### PR TITLE
print JSON error output to aid in debugging

### DIFF
--- a/pykeybasebot/cli.py
+++ b/pykeybasebot/cli.py
@@ -44,13 +44,11 @@ async def kblisten(keybase_cli: str, options, loop=None):
             raise KeybaseNotConnectedError(
                 "the keybase service is probably not running"
             )
+        line = line.decode().strip()
         try:
-            yield KbEvent.from_json(line.decode().strip())
+            yield KbEvent.from_json(line)
         except json.decoder.JSONDecodeError:
-            # The first few messages that come out aren't actually valid json.
-            # They just describe the options you've selected for listening.
-            # It would probably be better only to do this `pass` for a couple
-            # seconds.
+            logging.error(f"Unable to decode JSON output: {line}")
             pass
 
 


### PR DESCRIPTION
Lib would previously loop on this fatal error without any info as to why it thought the connection to the service had died.

```
DEBUG:root:executing command: ['keybase', 'chat', 'api-listen', '--filter-channel', '{"name": "yourbot,someoneelse"}']
ERROR:root:Unable to decode JSON output: 2019-09-08T08:43:43.653296-04:00 ▶ [ERRO keybase main.go:86] 001 Unable to find chat channel for "yourbot,someoneelse": In resolving 'yourbot': unknown user assertion
INFO:root:RECONNECT: the keybase service has died or disappeared. attempting to reconnect 100 times...
INFO:root:RECONNECT: sleeping 1 seconds...
```