### PR TITLE
Replace time.sleep calls with asyncio.sleep calls.

### DIFF
--- a/examples/3_scrolling_messages.py
+++ b/examples/3_scrolling_messages.py
@@ -13,7 +13,6 @@
 import asyncio
 import logging
 import sys
-import time
 
 import pykeybasebot.types.chat1 as chat1
 from pykeybasebot import Bot
@@ -51,7 +50,7 @@ async def scrolling_message(message, before="", after=""):
     while True:
         message = rotate(message)
         await bot.chat.edit(channel, msg_id, f"{before}{message}{after}")
-        time.sleep(0.5)
+        await asyncio.sleep(0.5)
 
 
 asyncio.run(

--- a/pykeybasebot/bot.py
+++ b/pykeybasebot/bot.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 import os
-import time
 from functools import wraps
 from typing import Optional
 
@@ -38,7 +37,7 @@ def _with_reconnect_to_keybase(keybase_bot_start_function):
                 logging.info(
                     f"RECONNECT: sleeping {SLEEP_SECS_BETWEEEN_RETRIES} seconds..."
                 )
-                time.sleep(SLEEP_SECS_BETWEEEN_RETRIES)
+                await asyncio.sleep(SLEEP_SECS_BETWEEEN_RETRIES)
 
     return wrapped_f
 


### PR DESCRIPTION
Calling time.sleep within an async function will block forward progress of the event loop. This commit changes `time.sleep` calls to `asyncio.sleep` calls.