### PR TITLE
don't error wrong user if not logged in

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
+.PHONY: test types clean
 PROTOCOL_PATH=$(GOPATH)/src/github.com/keybase/client/protocol
 AVDLC=$(PROTOCOL_PATH)/node_modules/.bin/avdlc
 
-.DEFAULT_GOAL := types
+test:
+	poetry run python -m pytest && flake8 && black . && isort -rc .
 
 types:
 	@mkdir -p pykeybasebot/types/{keybase1,gregor1,chat1,stellar1}/

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Then proceed as normal.
 To run tests, type
 
 ```
-poetry run python -m pytest
+make test
 ```
 
 Tests are admittedly weak. You could change that!
@@ -101,7 +101,7 @@ Then you can generate the types by using the provided Makefile in this repo.
 
 ```shell
 cd path/to/keybase-bot
-make
+make types
 ```
 
 Should you need to remove all the types for some reason, you can run `make clean`.

--- a/pykeybasebot/bot.py
+++ b/pykeybasebot/bot.py
@@ -127,9 +127,9 @@ class Bot:
             if self.username is None:
                 self.username = actual_username
             actual_logged_in = res["LoggedIn"]
-            if self.username.lower() != actual_username:
+            if actual_logged_in and (self.username.lower() != actual_username):
                 raise Exception(
-                    f"Logged in as {actual_username} instead of {self.username}. Please logout first"
+                    f"Logged in as {actual_username} instead of {self.username}. Please logout first."
                 )
             self._initialized = actual_logged_in
         return self._initialized

--- a/pykeybasebot/types/chat1/__init__.py
+++ b/pykeybasebot/types/chat1/__init__.py
@@ -17,12 +17,12 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Dict, List, Optional, Union
 
+from dataclasses_json import config, dataclass_json
 from typing_extensions import Literal
 
 import pykeybasebot.types.gregor1 as gregor1
 import pykeybasebot.types.keybase1 as keybase1
 import pykeybasebot.types.stellar1 as stellar1
-from dataclasses_json import config, dataclass_json
 
 
 @dataclass_json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pykeybasebot"
-version = "0.1.5"
+version = "0.1.6"
 description = "Officially supported Keybase python bot client library"
 authors = ["Keybase Engineering Team <alex@keyba.se>"]
 license = "BSD-3-Clause"

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,12 +1,11 @@
 import json
 import os
-from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+
+import pytest
 
 import pykeybasebot.types.chat1 as chat1
 import pykeybasebot.types.stellar1 as stellar1
-import pytest
 from pykeybasebot import EventType, KbEvent, Source
 
 


### PR DESCRIPTION
https://github.com/keybase/pykeybasebot/issues/19 is an issue where the service is, for some reason surfacing an empty string as the user before it knows about any users. it's likely a very recent issue. this change ensures that we only throw a "wrong logged in user" error if the wrong user is actually logged in. should fix pykeybasebot's exposure to the different behavior. 