### PR TITLE
logsend, handle chat service errors, paginate chat reads

### DIFF
--- a/pykeybasebot/bot.py
+++ b/pykeybasebot/bot.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import os
+import re
 from functools import wraps
 from typing import Optional
 
@@ -112,6 +113,13 @@ class Bot:
     @property
     def kvstore(self):
         return KVStoreClient(self)
+
+    async def logsend(self, msg):
+        only_word_characters = re.sub(r"\W+", " ", msg)
+        command = f'log send --no-confirm --feedback "{only_word_characters}"'
+        logging.debug(f"starting a log send with message: {only_word_characters}")
+        await self.submit(command, timeout_ms=10000)
+        logging.debug(f"finished logsend")
 
     async def ensure_initialized(self):
         if not await self._is_initialized():

--- a/pykeybasebot/chat_client.py
+++ b/pykeybasebot/chat_client.py
@@ -2,6 +2,7 @@ import json
 from typing import Dict, List, Optional
 
 from .types import chat1
+from .errors import ChatClientError
 
 
 class ChatClient:
@@ -119,4 +120,9 @@ class ChatClient:
 
     async def execute(self, command) -> Dict[str, str]:
         resp = await self.bot.submit("chat api", json.dumps(command).encode("utf-8"))
-        return resp["result"]
+        try:
+            return resp["result"]
+        except (TypeError, KeyError):
+            # this could happen if the running keybase client has an unexpected issue
+            full_response = json.dumps(resp).encode("utf-8")
+            raise ChatClientError(full_response)

--- a/pykeybasebot/chat_client.py
+++ b/pykeybasebot/chat_client.py
@@ -27,7 +27,7 @@ class ChatClient:
         await self.bot.ensure_initialized()
         read_options = {"channel": channel.to_dict()}
         if pagination is not None:
-            read_options['pagination'] = pagination.to_dict()
+            read_options["pagination"] = pagination.to_dict()
         read_request = {"method": "read", "params": {"options": read_options}}
         res = await self.execute(read_request)
         thread = chat1.Thread.from_dict(res)

--- a/pykeybasebot/errors.py
+++ b/pykeybasebot/errors.py
@@ -17,6 +17,10 @@ class DeleteNonExistentError(Error):
     CODE = 2762
 
 
+class ChatClientError(Error):
+    pass
+
+
 def disambiguate_error(e: Exception) -> Union[Exception, Error]:
     """
         Try to convert Exception presumably from kbsubmit()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ typing-extensions = "^3.7"
 [tool.poetry.dev-dependencies]
 pytest = "^5.1.1"
 twine = "^1.13"
-black = {version = "^18.3-alpha.0", allows-prereleases = true}
+black = {version = "^18.3-alpha.0", allow-prereleases = true}
 isort = "^4.3"
 flake8 = "^3.7"
 mypy = "^0.720.0"
@@ -35,6 +35,7 @@ combine_as_imports = true
 include_trailing_comma = true
 line_length = 88
 multi_line_output = 3
+known_third_party = "pyotp,yaml"
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
from running a personal bot (kbhonest), @joshblum notified me of a crashloop. 
it looks like reading messages from `keybase chat api` doesn't always cap the number that come out. i have not investigated this exhaustively (e.g. kbhonest's public channel is not capped, but team channels appear to be), but the service was periodically returning some kind of non-json error message, and pykeybasebot choked on it. 

* add the ability to request only the most recent `n` chat messages
* catch chat api errors coming back from the service and wrap them in a new error type
* add a simple logsend command